### PR TITLE
Move opentiny to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "gh-pages": "^6.1.0",
-    "opentiny": "6.9.33",
+    "opentiny": "^6.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
-    "opentiny": "6.9.33",
     "prop-types": "^15.6.2"
   },
   "resolutions": {
@@ -49,6 +48,7 @@
     "ip-address": "^10.1.1"
   },
   "peerDependencies": {
+    "opentiny": "^6.9.0",
     "react": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0",
     "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0"
   },
@@ -78,6 +78,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "gh-pages": "^6.1.0",
+    "opentiny": "6.9.33",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^6.0.1",
@@ -85,6 +86,6 @@
     "typescript": "~5.4.3",
     "vite": "^6.4.2"
   },
-  "version": "5.1.0-rc",
+  "version": "0.0.0",
   "name": "opentiny-react"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8482,7 +8482,7 @@ open@^10.0.3, open@^10.2.0:
     is-inside-container "^1.0.0"
     wsl-utils "^0.1.0"
 
-opentiny@6.9.33:
+opentiny@^6.9.0:
   version "6.9.33"
   resolved "https://registry.yarnpkg.com/opentiny/-/opentiny-6.9.33.tgz#7815d4c5b60aa35c1b168c4ebe06c50fc61b7dec"
   integrity sha512-AhSCQOXiBs/2Bodhk6s2ht7pT56cQ9fnKQ2KT1KG22xS50MCwQi4fxmL0n65w15od787/WCteYvAdBDaFVN56Q==


### PR DESCRIPTION
## What
- Moved opentiny from `dependencies` → `peerDependencies` (`^6.9.0`), and added it as a `devDependency` (`^6.9.0`) so the package can still build its own types.
- Changed the placeholder `version` from `5.1.0-rc` to `0.0.0` (the real version is set from the git tag at publish time, so the committed value is meaningless).

## Why
`opentiny` was pinned exactly (`6.9.33`) in dependencies. In an app that also depends on `opentiny` directly, a different patch version produced a duplicate, conflicting `opentiny` in the dependency tree. Since the wrapper uses opentiny only for TypeScript types (the editor is loaded at runtime from the `window.tinymce` global, never bundled), it should defer to the host app's copy.

As a peer dependency with a `^6.9.0` range, opentiny-react now binds to whatever `opentiny` the consuming app installs — one shared copy, no version conflicts — and we no longer need to bump this package for every `opentiny` patch release.